### PR TITLE
add package.json info: license, repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.1",
   "description": "Produce URLs to test HTTP servers with ephemeral ports",
   "main": "./index",
+  "license": "MIT",
+  "repository": "zeit/test-listen",
   "greenkeeper": {
     "emails": false
   },


### PR DESCRIPTION
I added a repository url so when discovered over npm, it'll display a link to github:

![image](https://cloud.githubusercontent.com/assets/2580598/23249712/01bf539a-f9a6-11e6-8a88-a587c9ba9d67.png)

Also, I added the MIT License in the `package.json` since you guys seem to be using it all over ZEIT projects. Correct me if I'm wrong.

